### PR TITLE
Fix VGG docs

### DIFF
--- a/R/vgg_feature_set.R
+++ b/R/vgg_feature_set.R
@@ -10,10 +10,10 @@
 #'
 #' @param impaths Character vector of image file paths.
 #' @param tier Character; one of "low", "mid", "high", or "semantic".
-#' @param model Preloaded Keras VGG-16 model object. If NULL, defaults to \code{keras::application_vgg16(pretrained = 'imagenet')}.
-#' @param target_size Numeric vector of length 2 specifying image resize dimensions (width, height).
-#' @param pooling Character string specifying spatial pooling; passed to \code{im_features::spatial_pooling}.
-#'        Defaults to "avg" (global average pooling). Other options: "none", "max", "resize_3x3", "resize_5x5", "resize_7x7".
+#' @param model Preloaded Keras VGG-16 model object. If NULL, defaults to \code{keras::application_vgg16(weights = 'imagenet')}. 
+#' @param target_size Numeric vector of length 2 specifying image resize dimensions (width, height). 
+#' @param pooling Character string specifying spatial pooling; passed to the \code{spatial_pooling} argument of \code{im_features}. 
+#'        Defaults to "avg" (global average pooling). Other options: "none", "max", "resize_3x3", "resize_5x5", "resize_7x7". 
 #' @return An S3 object of class \code{vgg_feature_set}, a list with components:
 #' \describe{
 #'   \item{features}{Numeric matrix (N_images × total_channels) of pooled features.}

--- a/man/extract_vgg_features.Rd
+++ b/man/extract_vgg_features.Rd
@@ -17,11 +17,11 @@ extract_vgg_features(
 
 \item{tier}{Character; one of "low", "mid", "high", or "semantic".}
 
-\item{model}{Preloaded Keras VGG-16 model object. If NULL, defaults to \code{keras::application_vgg16(pretrained = 'imagenet')}.}
+\item{model}{Preloaded Keras VGG-16 model object. If NULL, defaults to \code{keras::application_vgg16(weights = 'imagenet')}.}
 
 \item{target_size}{Numeric vector of length 2 specifying image resize dimensions (width, height).}
 
-\item{pooling}{Character string specifying spatial pooling; passed to \code{im_features::spatial_pooling}.
+\item{pooling}{Character string specifying spatial pooling; passed to the \code{spatial_pooling} argument of \code{im_features}.
 Defaults to "avg" (global average pooling). Other options: "none", "max", "resize_3x3", "resize_5x5", "resize_7x7".}
 }
 \value{


### PR DESCRIPTION
## Summary
- document VGG-16 model defaults using `weights`
- clarify pooling docs to reference `spatial_pooling` argument
- regenerate docs for `extract_vgg_features`

## Testing
- `R -q -e "roxygen2::roxygenise()"` *(fails: command not found)*