### PR TITLE
Validate parameters in thingsvision extract and align

### DIFF
--- a/man/tv_align.thingsvision_extractor.Rd
+++ b/man/tv_align.thingsvision_extractor.Rd
@@ -13,7 +13,7 @@
 
 \item{module_name}{The module name corresponding to the features being aligned.}
 
-\item{alignment_type}{Character string. The alignment method (e.g., "gLocal").}
+\item{alignment_type}{Character string. The alignment method (e.g., "gLocal"). Must be a scalar string. A warning is issued if the value is not recognized.}
 
 \item{...}{Additional arguments (currently ignored).}
 }

--- a/man/tv_extract.thingsvision_extractor.Rd
+++ b/man/tv_extract.thingsvision_extractor.Rd
@@ -30,7 +30,7 @@ before conversion to R. Defaults to "ndarray".}
 
 \item{output_dir}{Character string (optional). Directory to save features iteratively.}
 
-\item{step_size}{Integer (optional). Step size for saving if `output_dir` is used.}
+\item{step_size}{Integer (optional). Step size for saving if `output_dir` is used. Must be a finite numeric scalar.}
 
 \item{...}{Additional arguments (currently ignored).}
 }


### PR DESCRIPTION
## Summary
- require `step_size` to be numeric and finite in `tv_extract.thingsvision_extractor`
- check `alignment_type` is a scalar string in `tv_align.thingsvision_extractor` and warn for unknown types
- document the new argument validation rules

## Testing
- `R -q -e 'sessionInfo()'` *(fails: `R` not found)*