### PR TITLE
Add non-finite checks before PCA

### DIFF
--- a/R/residualize_tiers.R
+++ b/R/residualize_tiers.R
@@ -34,10 +34,11 @@
 #' Note: For applications like fMRI analysis where data might be processed in folds (e.g., for cross-validation),
 #' z-scoring should ideally be performed based on training fold statistics and then applied to test folds.
 #' This function, when applied to a whole dataset, uses statistics from the entire input for z-scoring.
+#' All matrices must contain only finite values; the function stops if any NA or Inf values are detected.
 #'
 #' @export
-residualize_tiers <- function(feature_list, numpcs = NULL, 
-                              pca_method = c("stats", "irlba"), 
+residualize_tiers <- function(feature_list, numpcs = NULL,
+                              pca_method = c("stats", "irlba"),
                               svd_tol = 1e-7,
                               scale_scores = TRUE) {
   if (!is.list(feature_list) || is.null(names(feature_list))) {
@@ -77,6 +78,9 @@ residualize_tiers <- function(feature_list, numpcs = NULL,
     X <- feature_list[[i]]
     if (!is.matrix(X)) {
       X <- as.matrix(X)
+    }
+    if (any(!is.finite(X))) {
+      stop(sprintf("Tier '%s' contains non-finite values (NA/Inf).", tier_name))
     }
     k_requested <- numpcs[i]
     P <- ncol(X)

--- a/man/residualize_tiers.Rd
+++ b/man/residualize_tiers.Rd
@@ -46,4 +46,5 @@ The process for each tier is as follows:
 To apply this full transformation (PCA and sequential residualization) to a new dataset, use the S3 method
 \code{predict(object, newdata)}, where \code{object} is the result of \code{residualize_tiers} and \code{newdata}
 is a named list of feature matrices matching the structure of the original \code{feature_list}.
+All matrices in \code{feature_list} must contain only finite numeric values; the function stops if any NA or Inf values are detected.
 }

--- a/tests/testthat/test-residualize_tiers.R
+++ b/tests/testthat/test-residualize_tiers.R
@@ -112,4 +112,26 @@ test_that("low and residualized high are orthogonal (new data)", {
   expect_lt(max(abs(orth2)), tol, "High-tier residuals should be orthogonal to the kept low-tier PCs (new data)")
 })
 
+test_that("error when NA values are present", {
+  feature_list_bad <- list(
+    tier1 = matrix(c(1, NA, 3, 4), nrow = 2),
+    tier2 = matrix(rnorm(4), nrow = 2)
+  )
+  expect_error(
+    residualize_tiers(feature_list_bad, numpcs = 1),
+    "non-finite values.*tier1"
+  )
+})
+
+test_that("error when Inf values are present", {
+  feature_list_bad <- list(
+    tier1 = matrix(c(1, Inf, 3, 4), nrow = 2),
+    tier2 = matrix(rnorm(4), nrow = 2)
+  )
+  expect_error(
+    residualize_tiers(feature_list_bad, numpcs = 1),
+    "non-finite values.*tier1"
+  )
+})
+
 # cat("All residualize_tiers tests passed ✔\n") # This cat() is more for interactive script, testthat has its own reporting 


### PR DESCRIPTION
## Summary
- guard against non-finite input in `residualize_tiers`
- document this new requirement
- test that NA and Inf values raise errors

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`