### PR TITLE
Check channels and document image_mse

### DIFF
--- a/R/mse.R
+++ b/R/mse.R
@@ -1,15 +1,25 @@
 #' Multiscale entropy for images
 #'
+#' Compute the entropy of the Hue, Saturation and Value components of an image
+#' across multiple blur scales.
 #'
 #' @import imager
 #' @import entropy
-#' @param im image of type `cimg` from `imager` package
+#' @param im image of type `cimg` from `imager` package. The function expects an
+#'   image with three colour channels. If a single-channel image is supplied it
+#'   will be converted with \code{add.colour()}, and an error is thrown if the
+#'   result does not contain exactly three channels.
 #' @param sf vector smoothing factors indicating the scales for entropy computation
 #' @param bins number of bins for computing information
+#' @return A named numeric vector with the mean multiscale entropy for the
+#'   \code{H}, \code{S} and \code{V} channels.
 #' @export
 image_mse <- function(im, sf=c(100, 50, 8, 4, 0), bins=16) {
-  if (length(channels(im)) ==1) {
+  if (length(channels(im)) == 1) {
     im <- add.colour(im)
+  }
+  if (length(channels(im)) != 3) {
+    stop("image_mse expects an image with 3 colour channels after add.colour()")
   }
 
   hsvim <- RGBtoHSV(im)
@@ -39,5 +49,7 @@ image_mse <- function(im, sf=c(100, 50, 8, 4, 0), bins=16) {
   })
 
   ret <- do.call(rbind, ret)
-  colMeans(as.matrix(ret[,2:4]))
+  out <- colMeans(as.matrix(ret[,2:4]))
+  names(out) <- c("H", "S", "V")
+  out
 }

--- a/man/image_mse.Rd
+++ b/man/image_mse.Rd
@@ -7,11 +7,18 @@
 image_mse(im, sf = c(100, 50, 8, 4, 0), bins = 16)
 }
 \arguments{
-\item{im}{image of type `cimg` from `imager` package}
+\item{im}{image of type `cimg` from `imager` package. The function expects an
+image with three colour channels. If a single-channel image is supplied it will
+be converted with \code{add.colour()}, and an error is thrown if the result does
+not contain exactly three channels.}
 
 \item{sf}{vector smoothing factors indicating the scales for entropy computation}
 
 \item{bins}{number of bins for computing information}
+}
+\value{
+A named numeric vector with the mean multiscale entropy for the \code{H},
+\code{S} and \code{V} channels.
 }
 \description{
 Multiscale entropy for images


### PR DESCRIPTION
## Summary
- enforce that images passed to `image_mse` have 3 channels
- clarify the behaviour in the documentation
- return a named vector for HSV channels

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*