### PR TITLE
Fix subsampling size in feature similarity

### DIFF
--- a/R/im_features.R
+++ b/R/im_features.R
@@ -60,7 +60,8 @@ im_feature_sim <- function(impaths, layers, model=NULL, target_size=c(224,224),
     if (subsamp_prop < 1) {
       f1 <- im_features(impaths[1], layers=layers, model=model)
       subsamp_ind <- lapply(f1, function(feat) {
-        ind <- sample(1:length(feat), as.integer(length(feat) * subsamp_prop))
+        size <- max(1L, round(length(feat) * subsamp_prop))
+        sample(seq_along(feat), size)
       })
     }
 


### PR DESCRIPTION
## Summary
- prevent errors on very small `subsamp_prop` values by ensuring the computed sample size is at least 1

## Testing
- `R` not installed in container