### PR TITLE
Fix dimnames assignment in im_features_tv

### DIFF
--- a/R/im_features_tv.R
+++ b/R/im_features_tv.R
@@ -275,7 +275,7 @@ im_features_tv <- function(impaths, model_name, source, module_name,
        # Attempt to add rownames
        img_basenames <- try(tools::file_path_sans_ext(basename(impaths)), silent = TRUE)
        if (!inherits(img_basenames, "try-error") && length(img_basenames) == NROW(features)) {
-          try(rownames(features) <- img_basenames, silent = TRUE)
+          features <- .add_feature_dimnames(features, img_basenames)
        } else {
           warning("Could not set rownames for features. Number of images might not match feature rows, or basename extraction failed.")
        }
@@ -507,5 +507,16 @@ im_feature_sim_tv <- function(impaths, model_name, source, module_names,
      return(list())
   }
 
-  return(sim_matrices)
+return(sim_matrices)
 }
+
+#' @keywords internal
+.add_feature_dimnames <- function(features, img_basenames) {
+  if (length(dim(features)) > 2) {
+    dimnames(features)[[1]] <- img_basenames
+  } else {
+    rownames(features) <- img_basenames
+  }
+  features
+}
+

--- a/tests/testthat/test-add_feature_dimnames.R
+++ b/tests/testthat/test-add_feature_dimnames.R
@@ -1,0 +1,16 @@
+library(testthat)
+library(imfeatures)
+
+context(".add_feature_dimnames helper function")
+
+test_that("dimnames set for matrix", {
+  mat <- matrix(1:4, nrow = 2)
+  out <- imfeatures:::.add_feature_dimnames(mat, c("img1", "img2"))
+  expect_equal(rownames(out), c("img1", "img2"))
+})
+
+test_that("dimnames set for array", {
+  arr <- array(1:8, dim = c(2,2,2))
+  out <- imfeatures:::.add_feature_dimnames(arr, c("img1", "img2"))
+  expect_equal(dimnames(out)[[1]], c("img1", "img2"))
+})


### PR DESCRIPTION
## Summary
- add `.add_feature_dimnames` helper
- use it in `im_features_tv`
- test dimnames for matrices and arrays

## Testing
- `devtools::test()` *(fails: `R` not installed)*