### PR TITLE
Fix zero_borders edge case

### DIFF
--- a/R/entropy.R
+++ b/R/entropy.R
@@ -186,10 +186,17 @@ run_filterbank <- function(fimg, fbank) {
 zero_borders <- function(resp_val, nlines=2) {
   nr <- nrow(resp_val)
   nc <- ncol(resp_val)
-  resp_val[1:nlines,] <- 0
-  resp_val[, 1:nlines] <- 0
-  resp_val[(nr-nlines):nr,] <- 0
-  resp_val[, (nc-nlines):nc] <- 0
+
+  # Clamp nlines to valid range and ensure non-negative
+  nlines <- max(0, min(nlines, nr - 1, nc - 1))
+
+  if (nlines > 0) {
+    resp_val[1:nlines, ] <- 0
+    resp_val[, 1:nlines] <- 0
+    resp_val[(nr - nlines + 1):nr, ] <- 0
+    resp_val[, (nc - nlines + 1):nc] <- 0
+  }
+
   resp_val
 }
 

--- a/tests/testthat/test-zero_borders.R
+++ b/tests/testthat/test-zero_borders.R
@@ -1,0 +1,13 @@
+library(testthat)
+library(imfeatures)
+
+context("zero_borders edge cases")
+
+test_that("tiny matrices keep dimensions", {
+  m <- matrix(1:4, nrow = 2)
+  res <- imfeatures:::zero_borders(m, nlines = 2)
+  expect_equal(dim(res), c(2, 2))
+
+  res2 <- imfeatures:::zero_borders(m, nlines = 5)
+  expect_equal(dim(res2), c(2, 2))
+})


### PR DESCRIPTION
## Summary
- clamp `nlines` in `zero_borders()` so indices stay valid
- test that tiny matrices keep the same size after applying `zero_borders`

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: `R` not found)*