### PR TITLE
Fix do_counting cutoff for small images

### DIFF
--- a/R/entropy.R
+++ b/R/entropy.R
@@ -213,8 +213,13 @@ do_counting <- function(fres, maxdiag=80, circ_bins=48) {
   complex_before = sum(resp_val)/normalize_fac
 
 
-  cutoff = sort(as.vector(resp_val), decreasing=TRUE)[10000] # get 10000th highest response for cutting of beneath
-  message("[R] do_counting: Calculated cutoff (k-th=10000): ", cutoff)
+  # Determine the k-th largest response to use as cutoff. For small images
+  # length(resp_val) may be < 10,000, so we clamp k to the number of pixels.
+  k <- min(10000L, length(resp_val))
+  cutoff = sort(as.vector(resp_val), decreasing = TRUE)[k]
+  # If k equals the number of pixels the cutoff will be the minimum response
+  # value, meaning no responses are removed.
+  message(sprintf("[R] do_counting: Calculated cutoff (k=%d): %f", k, cutoff))
   resp_val[resp_val<cutoff] = 0
   message("[R] do_counting: Range resp_val (after cutoff): [", 
           min(resp_val), ", ", max(resp_val), "]")

--- a/tests/testthat/test-do_counting.R
+++ b/tests/testthat/test-do_counting.R
@@ -1,0 +1,20 @@
+library(testthat)
+library(imfeatures)
+
+context("do_counting handles small images")
+
+test_that("do_counting works on very small images", {
+  img <- matrix(runif(9), nrow = 3)
+  fimg <- list(
+    file = "matrix",
+    img = NULL,
+    image_raw = img,
+    image_size = dim(img)
+  )
+  class(fimg) <- c("filtered_image", "list")
+  fbank <- filter_bank(4, 3)
+  fres  <- run_filterbank(fimg, fbank)
+  expect_silent(res <- do_counting(fres))
+  expect_true(is.list(res))
+  expect_true(all(c("counts", "complex_before") %in% names(res)))
+})


### PR DESCRIPTION
## Summary
- avoid NA cutoffs on small images by clamping the k-th response
- document behavior when k equals number of pixels
- test do_counting on a tiny synthetic matrix

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*