### PR TITLE
Add filter_length validation and tests

### DIFF
--- a/R/entropy.R
+++ b/R/entropy.R
@@ -375,10 +375,13 @@ do_statistics <- function(counts, bins_vec) {
 #'
 #' @export
 edge_entropy <- function(image, max_pixels=300*400, maxdiag=500, gabor_bins=24,
-                         filter_length=31, circ_bins=48, 
+                         filter_length=31, circ_bins=48,
                          ranges=list(c(20,80), c(80, 160), c(160,240)),
                          use_cpp=TRUE) {
-  
+
+  if (!is.numeric(filter_length) || filter_length <= 0 || filter_length %% 2 == 0)
+      stop("'filter_length' must be a positive odd integer")
+
   # Check if image is a file path or a matrix
   if (is.character(image) && length(image) == 1) {
     # It's a file path

--- a/tests/testthat/test-edge_entropy.R
+++ b/tests/testthat/test-edge_entropy.R
@@ -1,0 +1,28 @@
+library(testthat)
+library(imfeatures)
+
+context("edge_entropy filter_length validation")
+
+img_matrix <- matrix(1:9, nrow = 3)
+
+# C++ branch
+expect_error(
+  edge_entropy(img_matrix, filter_length = 2, use_cpp = TRUE),
+  "'filter_length' must be a positive odd integer"
+)
+
+expect_error(
+  edge_entropy(img_matrix, filter_length = -1, use_cpp = TRUE),
+  "'filter_length' must be a positive odd integer"
+)
+
+# R branch
+expect_error(
+  edge_entropy(img_matrix, filter_length = 2, use_cpp = FALSE),
+  "'filter_length' must be a positive odd integer"
+)
+
+expect_error(
+  edge_entropy(img_matrix, filter_length = -1, use_cpp = FALSE),
+  "'filter_length' must be a positive odd integer"
+)


### PR DESCRIPTION
## Summary
- check `filter_length` argument at the start of `edge_entropy`
- add unit tests ensuring invalid `filter_length` errors for both C++ and R implementations

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: `R` not found)*