### PR TITLE
Add image path check in clip_features

### DIFF
--- a/R/clip_features.R
+++ b/R/clip_features.R
@@ -22,6 +22,10 @@ clip_features <- function(impath,
 
   device <- match.arg(device)
 
+  if (!file.exists(impath)) {
+    stop("Image file not found: ", impath)
+  }
+
   # Python helper function string
   py_helpers <- "
 import torch


### PR DESCRIPTION
## Summary
- stop early if the image path doesn't exist

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`