### PR TITLE
Fix tests by providing custom mocking helper

### DIFF
--- a/tests/testthat/helper-mocks.R
+++ b/tests/testthat/helper-mocks.R
@@ -1,0 +1,62 @@
+with_mocked_bindings <- function(..., .env = parent.frame()) {
+  dots <- substitute(list(...))
+  code <- dots[[length(dots)]]
+  mock_exprs <- dots[-length(dots)]
+  mocks <- lapply(mock_exprs, eval, envir = parent.frame())
+  names(mocks) <- names(mock_exprs)
+
+  restore <- list()
+
+  apply_mock <- function(name, value) {
+    pkg <- NULL
+    target_env <- .env
+    obj <- name
+    if (grepl("::", name)) {
+      pkg <- sub("::.*", "", name)
+      obj <- sub(".*::", "", name)
+      target_env <- getNamespace(pkg)
+    }
+
+    if (grepl("\$", obj)) {
+      pieces <- strsplit(obj, "\$", fixed = TRUE)[[1]]
+      container_name <- pieces[[1]]
+      field_name <- pieces[[2]]
+      container <- get(container_name, envir = target_env)
+      restore[[name]] <<- container[[field_name]]
+      container[[field_name]] <- value
+      assign(container_name, container, envir = target_env)
+    } else {
+      restore[[name]] <<- get(obj, envir = target_env)
+      assign(obj, value, envir = target_env)
+    }
+  }
+
+  for (nm in names(mocks)) {
+    apply_mock(nm, mocks[[nm]])
+  }
+
+  on.exit({
+    for (nm in rev(names(restore))) {
+      pkg <- NULL
+      target_env <- .env
+      obj <- nm
+      if (grepl("::", nm)) {
+        pkg <- sub("::.*", "", nm)
+        obj <- sub(".*::", "", nm)
+        target_env <- getNamespace(pkg)
+      }
+      if (grepl("\$", obj)) {
+        pieces <- strsplit(obj, "\$", fixed = TRUE)[[1]]
+        container_name <- pieces[[1]]
+        field_name <- pieces[[2]]
+        container <- get(container_name, envir = target_env)
+        container[[field_name]] <- restore[[nm]]
+        assign(container_name, container, envir = target_env)
+      } else {
+        assign(obj, restore[[nm]], envir = target_env)
+      }
+    }
+  }, add = TRUE)
+
+  eval(code, envir = parent.frame())
+}

--- a/tests/testthat/test-im_feature_sim.R
+++ b/tests/testthat/test-im_feature_sim.R
@@ -2,10 +2,7 @@ library(testthat)
 library(imfeatures)
 
 context("im_feature_sim")
-
-with_mocked_bindings <- function(..., .env = environment()) {
-  withr::local_bindings(..., .env = .env)
-}
+# with_mocked_bindings defined in helper-mocks.R
 
 
 test_that("subsampling logic works and output matrices are symmetric", {

--- a/tests/testthat/test-im_features.R
+++ b/tests/testthat/test-im_features.R
@@ -3,11 +3,7 @@ library(imfeatures)
 
 context("im_features")
 
-# helper to mock dependencies
-
-with_mocked_bindings <- function(..., .env = environment()) {
-  withr::local_bindings(..., .env = .env)
-}
+# helper to mock dependencies provided by helper-mocks.R
 
 
 test_that("im_features errors on missing file paths", {

--- a/tests/testthat/test-process_feature_map.R
+++ b/tests/testthat/test-process_feature_map.R
@@ -2,11 +2,7 @@ library(testthat)
 library(imfeatures)
 
 context(".process_feature_map helper function")
-
-# helper to mock dependencies
-with_mocked_bindings <- function(..., .env = environment()) {
-  withr::local_bindings(..., .env = .env)
-}
+# with_mocked_bindings defined in helper-mocks.R
 
 test_that("average pooling returns correct values for 4D input", {
   # Create a dummy feature map: batch=1, H=2, W=2, C=2


### PR DESCRIPTION
## Summary
- add `helper-mocks.R` providing a new `with_mocked_bindings()` implementation
- update tests to rely on the helper

## Testing
- `R -q -e 'sessionInfo()'` *(fails: command not found)*