### PR TITLE
Add input validation tests for C++ interface

### DIFF
--- a/tests/testthat/test-cpp-interface.R
+++ b/tests/testthat/test-cpp-interface.R
@@ -1,0 +1,29 @@
+context("edge_entropy_cpp input validation")
+
+# Using small dummy matrix
+img <- matrix(1:4, nrow = 2)
+
+# invalid image shape
+expect_error(edge_entropy_cpp(matrix(numeric(0), nrow=0, ncol=0)),
+             "Input image has zero dimensions")
+
+# invalid maxdiag
+expect_error(edge_entropy_cpp(img, maxdiag = 0),
+             "maxdiag must be positive")
+
+# invalid gabor_bins
+expect_error(edge_entropy_cpp(img, gabor_bins = 0),
+             "gabor_bins must be positive")
+
+# invalid filter_length (even)
+expect_error(edge_entropy_cpp(img, filter_length = 2),
+             "filter_length must be positive and odd")
+
+# invalid circ_bins
+expect_error(edge_entropy_cpp(img, circ_bins = 0),
+             "circ_bins must be positive")
+
+# invalid ranges type
+expect_error(edge_entropy_cpp(img, rangesSEXP = 1),
+             "Parameter 'ranges' must be a list")
+


### PR DESCRIPTION
## Summary
- add a new test checking the exported C++ function `edge_entropy_cpp` rejects invalid inputs

## Testing
- `R -q -e "Rcpp::compileAttributes()"` *(fails: command not found)*
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683caa302f24832d9ad76b3a3baa4f41